### PR TITLE
long -> ulong

### DIFF
--- a/driver/universe.c
+++ b/driver/universe.c
@@ -79,8 +79,8 @@ struct inode;
 static unsigned long size_to_reserve		= 0x10000000; // 256 MB reserved
 static unsigned long reserve_from_address	= 0xC0000000; // reserve from high mem
 
-module_param(size_to_reserve, long, 0);
-module_param(reserve_from_address, long, 0);
+module_param(size_to_reserve, ulong, 0);
+module_param(reserve_from_address, ulong, 0);
 MODULE_PARM_DESC(size_to_reserve, "Give the size of pci space to reserve. ");
 MODULE_PARM_DESC(reserve_from_address, "Give a starting pci address from which to reserve.");
 MODULE_LICENSE("GPL");


### PR DESCRIPTION
I noticed that the messages from the universe driver in dmesg didn't match what I was setting in the universe rc script, i.e. my script would be:

```
size_to_reserve="size_to_reserve=0x10000000"
reserve_from_address="reserve_from_address=0x90000000"
```

and then dmesg would say:

```
Error reserving memory from 0x10000000 to 0x1fffffff
```

This fix uses the correct type for the module parameters. It has been tested and known to work with CRUX 2.7.1 and kernel version 2.6.39.4.
